### PR TITLE
Adding git & build info to --version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13-xlarge]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,13 +27,18 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
 
+    - name: Store git commit hash
+      run: |
+        commit_hash=$(git rev-parse --short HEAD)
+        echo "COMMIT_HASH=$commit_hash" >> $GITHUB_ENV
+
     - name: Rename binary
       shell: bash
       run: |
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
-          mv ./target/debug/e4e-data-management-rust.exe ./target/debug/e4e-data-management-rust-${{ matrix.os }}.exe
+          mv ./target/debug/e4e-data-management-rust.exe ./target/debug/e4e-data-management-rust-${{ matrix.os }}-${{ env.COMMIT_HASH }}.exe
         else
-          mv ./target/debug/e4e-data-management-rust ./target/debug/e4e-data-management-rust-${{ matrix.os }}
+          mv ./target/debug/e4e-data-management-rust ./target/debug/e4e-data-management-rust-${{ matrix.os }}-${{ env.COMMIT_HASH }}
         fi
 
     - name: Upload Build Artifacts

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,18 +27,14 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
 
-    - name: Store git commit hash
-      run: |
-        commit_hash=$(git rev-parse --short HEAD)
-        echo "COMMIT_HASH=$commit_hash" >> $GITHUB_ENV
-
     - name: Rename binary
       shell: bash
       run: |
+        hash_short=${GITHUB_SHA:0:7}
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
-          mv ./target/debug/e4e-data-management-rust.exe ./target/debug/e4e-data-management-rust-${{ matrix.os }}-${{ env.COMMIT_HASH }}.exe
+          mv ./target/debug/e4e-data-management-rust.exe ./target/debug/e4e-data-management-rust-${{ matrix.os }}-$hash_short.exe
         else
-          mv ./target/debug/e4e-data-management-rust ./target/debug/e4e-data-management-rust-${{ matrix.os }}-${{ env.COMMIT_HASH }}
+          mv ./target/debug/e4e-data-management-rust ./target/debug/e4e-data-management-rust-${{ matrix.os }}-$hash_short
         fi
 
     - name: Upload Build Artifacts

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Build
       run: cargo build --verbose
@@ -37,7 +37,7 @@ jobs:
         fi
 
     - name: Upload Build Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os }}
         path: ./target/debug/e4e-data-management-rust-${{ matrix.os }}*

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,34 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
 
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13-xlarge]
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Build
       run: cargo build --verbose
+
     - name: Run tests
       run: cargo test --verbose
+
+    - name: Rename binary
+      shell: bash
+      run: |
+        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+          mv ./target/debug/e4e-data-management-rust.exe ./target/debug/e4e-data-management-rust-${{ matrix.os }}.exe
+        else
+          mv ./target/debug/e4e-data-management-rust ./target/debug/e4e-data-management-rust-${{ matrix.os }}
+        fi
+
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.os }}
+        path: ./target/debug/e4e-data-management-rust-${{ matrix.os }}*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ chrono = { version = "0.4.31", features = ["rustc-serialize", "serde"] }
 clap = { version = "4.4.7", features = ["derive"] }
 serde = { version = "1.0.190", features = ["derive"] }
 toml = "0.8.8"
+
+[build-dependencies]
+chrono = "0.4.31"

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ use std::{
 
 fn main() -> Result<(), Box<dyn Error>> {
 
-    let git_output = Command::new("git").args(&["rev-parse", "HEAD"]).output()?;
+    let git_output = Command::new("git").args(["rev-parse", "HEAD"]).output()?;
     let git_hash = String::from_utf8(git_output.stdout)?;
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
     println!("cargo:rustc-env=COMPILE_TIME={}", chrono::Local::now());

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,21 @@
+use std::{
+    env, error::Error, fs::File, io::{BufWriter, Write}, path::Path, process::Command
+};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let out_dir = env::var("OUT_DIR")?;
+    let dest_path = Path::new(&out_dir).join("version_string.txt");
+    let mut f = BufWriter::new(File::create(&dest_path)?);
+
+
+    let version = option_env!("PROJECT_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+    let git_output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
+    let git_hash = String::from_utf8(git_output.stdout).unwrap();
+    let version_string = format!(
+"
+version: {}
+git commit hash: {}build time: {}", version, git_hash, chrono::Local::now());
+    write!(f, "{}", version_string)?;
+
+    Ok(())
+}

--- a/build.rs
+++ b/build.rs
@@ -11,11 +11,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let version = option_env!("PROJECT_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
     let git_output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(git_output.stdout).unwrap();
-    let version_string = format!(
-"
+    write!(f, "
 version: {}
-git commit hash: {}build time: {}", version, git_hash, chrono::Local::now());
-    write!(f, "{}", version_string)?;
-
+git commit hash: {}build time: {}", version, git_hash, chrono::Local::now())?;
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -4,8 +4,8 @@ use std::{
 
 fn main() -> Result<(), Box<dyn Error>> {
 
-    let git_output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
-    let git_hash = String::from_utf8(git_output.stdout).unwrap();
+    let git_output = Command::new("git").args(&["rev-parse", "HEAD"]).output()?;
+    let git_hash = String::from_utf8(git_output.stdout)?;
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
     println!("cargo:rustc-env=COMPILE_TIME={}", chrono::Local::now());
     Ok(())

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,12 @@
 use std::{
-    env, error::Error, fs::File, io::{BufWriter, Write}, path::Path, process::Command
+    error::Error, process::Command
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let out_dir = env::var("OUT_DIR")?;
-    let dest_path = Path::new(&out_dir).join("version_string.txt");
-    let mut f = BufWriter::new(File::create(&dest_path)?);
 
-
-    let version = option_env!("PROJECT_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
     let git_output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(git_output.stdout).unwrap();
-    write!(f, "
-version: {}
-git commit hash: {}build time: {}", version, git_hash, chrono::Local::now())?;
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    println!("cargo:rustc-env=COMPILE_TIME={}", chrono::Local::now());
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,6 @@
-use std::{
-    error::Error, process::Command
-};
+use std::{error::Error, process::Command};
 
 fn main() -> Result<(), Box<dyn Error>> {
-
     let git_output = Command::new("git").args(["rev-parse", "HEAD"]).output()?;
     let git_hash = String::from_utf8(git_output.stdout)?;
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,8 +3,11 @@ use crate::config::E4EDMConfig;
 use anyhow::Result;
 use clap::Parser;
 
+static VERSION_STR: &'static str = include_str!(concat!(env!("OUT_DIR"), "/version_string.txt"));
+
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
+#[command(long_version = VERSION_STR)]
 #[command(propagate_version = true)]
 pub struct Cli {
     #[command(subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,14 +18,14 @@ impl Cli {
     pub fn exec(&self) -> Result<()> {
         let config = E4EDMConfig::build().unwrap();
         match &self.command {
-            Commands::InitDataset(args) => {}
-            Commands::InitMission(args) => {}
-            Commands::Add(args) => {}
+            Commands::InitDataset(_args) => {}
+            Commands::InitMission(_args) => {}
+            Commands::Add(_args) => {}
             Commands::Activate => {}
             Commands::Status => {}
             Commands::Config => {}
-            Commands::Commit(args) => {}
-            Commands::Push(args) => {}
+            Commands::Commit(_args) => {}
+            Commands::Push(_args) => {}
         }
 
         let _ = config.save();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use crate::config::E4EDMConfig;
 use anyhow::Result;
 use clap::Parser;
 
-static VERSION_STR: &'static str = include_str!(concat!(env!("OUT_DIR"), "/version_string.txt"));
+static VERSION_STR: &str = concat!("\nversion: ", env!("CARGO_PKG_VERSION"), "\ngit hash: ", env!("GIT_HASH"), "\ncompile_time: ", env!("COMPILE_TIME"));
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,14 @@ use crate::config::E4EDMConfig;
 use anyhow::Result;
 use clap::Parser;
 
-static VERSION_STR: &str = concat!("\nversion: ", env!("CARGO_PKG_VERSION"), "\ngit hash: ", env!("GIT_HASH"), "\ncompile_time: ", env!("COMPILE_TIME"));
+static VERSION_STR: &str = concat!(
+    "\nversion: ",
+    env!("CARGO_PKG_VERSION"),
+    "\ngit hash: ",
+    env!("GIT_HASH"),
+    "\ncompile_time: ",
+    env!("COMPILE_TIME")
+);
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct E4EDMConfig {


### PR DESCRIPTION
Fixes #9. Adds git commit hash and build time to the long version text, i.e. using `-V` still only prints the app version but using `--version` will print the app version, commit hash, and build timestamp. This is currently done by creating the text to print using `build.rs`, and loading it in from the build directory during runtime. If there are cleaner ways to do this, suggestions are welcome. 