### PR TITLE
fix: Correct Dataset and Manifest root paths

### DIFF
--- a/src/commands/init_dataset.rs
+++ b/src/commands/init_dataset.rs
@@ -7,7 +7,7 @@ use super::InitDatasetArgs;
 
 pub(crate) fn init_dataset(args: &InitDatasetArgs, config: &mut E4EDMConfig) -> Result<()> {
     let manifest_root = args.path.to_owned()
-        .unwrap_or(ProjectDirs::from("com", "Engineers For Exploration", "E4EDataManagement").unwrap().config_dir().to_path_buf());
+        .unwrap_or(ProjectDirs::from("edu", "UCSD Engineers For Exploration", "E4EDataManagement").unwrap().config_dir().to_path_buf());
 
     let dataset_name = format!("{year:04}.{month:02}.{day:02}.{project}.{location}", 
         year = args.date.year(),

--- a/src/commands/init_dataset.rs
+++ b/src/commands/init_dataset.rs
@@ -6,6 +6,9 @@ use directories::ProjectDirs;
 use super::InitDatasetArgs;
 
 pub(crate) fn init_dataset(args: &InitDatasetArgs, config: &mut E4EDMConfig) -> Result<()> {
+    let manifest_root = args.path.to_owned()
+        .unwrap_or(ProjectDirs::from("com", "Engineers For Exploration", "E4EDataManagement").unwrap().config_dir().to_path_buf());
+
     let dataset_name = format!("{year:04}.{month:02}.{day:02}.{project}.{location}", 
         year = args.date.year(),
         month = args.date.month(),
@@ -13,14 +16,12 @@ pub(crate) fn init_dataset(args: &InitDatasetArgs, config: &mut E4EDMConfig) -> 
         project = args.project,
         location = args.location
     );
-    let dataset_path = args.path.to_owned()
-        .unwrap_or(ProjectDirs::from("com", "Engineers For Exploration", "E4EDataManagement").unwrap().config_dir().to_path_buf())
-        .join(dataset_name.clone());
 
     if config.datasets.contains_key(&dataset_name) {
         bail!("Dataset with that name already exists!");
     }
+
     config.active_dataset = Some(dataset_name.clone());
-    config.datasets.insert(dataset_name, build_dataset(dataset_path, args.date.with_timezone(&Utc)));
+    config.datasets.insert(dataset_name.clone(), build_dataset(dataset_name, manifest_root, args.date.with_timezone(&Utc)));
     Ok(())
 }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -28,7 +28,7 @@ pub struct Dataset {
 }
 
 pub fn build_dataset(name: String, root: std::path::PathBuf, day_0: DateTime<Utc>) -> Dataset {
-    let dataset_path = root.clone().join(name.clone());
+    let dataset_path = root.join(name.clone());
     Dataset {
         root: dataset_path,
         day_0,

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -4,6 +4,7 @@ use chrono::DateTime;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::vec;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -26,10 +27,10 @@ pub struct Dataset {
     version: String,
 }
 
-pub fn build_dataset(root: std::path::PathBuf, day_0: DateTime<Utc>) -> Dataset {
-    let manifest_path = root.join("manifest.json");
+pub fn build_dataset(name: String, root: std::path::PathBuf, day_0: DateTime<Utc>) -> Dataset {
+    let dataset_path = root.clone().join(name.clone());
     Dataset {
-        root,
+        root: dataset_path,
         day_0,
         last_country: None,
         last_region: None,
@@ -39,7 +40,7 @@ pub fn build_dataset(root: std::path::PathBuf, day_0: DateTime<Utc>) -> Dataset 
         sites: vec![],
         devices: vec![],
         missions: HashMap::new(),
-        manifest: Manifest::new(manifest_path, None),
+        manifest: Manifest::new(PathBuf::from(name).join("manifest.json"), Some(root)),
         committed_files: vec![],
         staged_files: vec![],
         pushed: false,


### PR DESCRIPTION
This PR corrects the root and paths used in Dataset and Manifest, based on @ntlhui's comment [here](https://github.com/UCSD-E4E/e4e-data-management-rust/pull/17#issuecomment-1884237513). Specifically, for the following directory structure:
```
dir1/
	2024.01.Project.Location/
		ED-00/
			Mission1/
				data
				manifest.json
				metadata.json
			Mission2/
				data
				manifest.json
				metadata.json
		ED-01/
			Mission3/
				data
				manifest.json
				metadata.json
			Mission4/
				data
				manifest.json
				metadata.json
		.e4edm.pkl
		manifest.json
		readme.md
```
* the `root` of a `Dataset` struct is the absolute path to the dataset's directory, i.e. `.../dir1/2024.01.Project.Location/` for the above dataset
* the `root` of a `Manifest` belonging to a `Dataset` is the absolute path to the project directory, i.e.  the absolute path to `dir1` for `2024.01.Project.Location/manifest.json`
* the `root` of a `Manifest` belonging to a `Mission` is the absolute path to the mission directory, i.e. the absolute path to `Mission1` for `dir1/2024.01.Project.Location/ED-00/Mission1/manifest.json` (this is not included in the PR, but will be included with #17)
* the `path` of a `Manifest` is the absolute path to itself