### PR TITLE
chore: Fixes and silences warnings, formats code

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
-use crate::commands::{Commands, init_dataset::init_dataset, init_mission::init_mission};
+use crate::commands::{init_dataset::init_dataset, init_mission::init_mission, Commands};
 use crate::config::E4EDMConfig;
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use clap::Parser;
 
 #[derive(Parser)]
@@ -17,12 +17,12 @@ impl Cli {
         match &self.command {
             Commands::InitDataset(args) => init_dataset(args, &mut config),
             Commands::InitMission(args) => init_mission(args, &mut config),
-            Commands::Add(args) => bail!("unimplemented"),
+            Commands::Add(_args) => bail!("unimplemented"),
             Commands::Activate => bail!("unimplemented"),
             Commands::Status => bail!("unimplemented"),
             Commands::Config => bail!("unimplemented"),
-            Commands::Commit(args) => bail!("unimplemented"),
-            Commands::Push(args) => bail!("unimplemented"),
+            Commands::Commit(_args) => bail!("unimplemented"),
+            Commands::Push(_args) => bail!("unimplemented"),
         }?;
 
         config.save()?;

--- a/src/commands/init_dataset.rs
+++ b/src/commands/init_dataset.rs
@@ -1,15 +1,20 @@
-use chrono::{Datelike, Utc};
 use crate::{config::E4EDMConfig, dataset::build_dataset};
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
+use chrono::{Datelike, Utc};
 use directories::ProjectDirs;
 
 use super::InitDatasetArgs;
 
 pub(crate) fn init_dataset(args: &InitDatasetArgs, config: &mut E4EDMConfig) -> Result<()> {
-    let manifest_root = args.path.to_owned()
-        .unwrap_or(ProjectDirs::from("edu", "UCSD Engineers For Exploration", "E4EDataManagement").unwrap().config_dir().to_path_buf());
+    let manifest_root = args.path.to_owned().unwrap_or(
+        ProjectDirs::from("edu", "UCSD Engineers For Exploration", "E4EDataManagement")
+            .unwrap()
+            .config_dir()
+            .to_path_buf(),
+    );
 
-    let dataset_name = format!("{year:04}.{month:02}.{day:02}.{project}.{location}", 
+    let dataset_name = format!(
+        "{year:04}.{month:02}.{day:02}.{project}.{location}",
         year = args.date.year(),
         month = args.date.month(),
         day = args.date.day(),
@@ -22,6 +27,9 @@ pub(crate) fn init_dataset(args: &InitDatasetArgs, config: &mut E4EDMConfig) -> 
     }
 
     config.active_dataset = Some(dataset_name.clone());
-    config.datasets.insert(dataset_name.clone(), build_dataset(dataset_name, manifest_root, args.date.with_timezone(&Utc)));
+    config.datasets.insert(
+        dataset_name.clone(),
+        build_dataset(dataset_name, manifest_root, args.date.with_timezone(&Utc)),
+    );
     Ok(())
 }

--- a/src/commands/init_mission.rs
+++ b/src/commands/init_mission.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 
 use crate::{config::E4EDMConfig, dataset::build_mission_metadata};
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct E4EDMConfig {

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -31,17 +31,25 @@ pub struct Dataset {
 impl Dataset {
     pub fn add_mission(&mut self, metadata: Metadata) -> String {
         let expedition_day = (metadata.timestamp - self.day_0).num_days();
-        let mission_path = self.root.clone()
+        let mission_path = self
+            .root
+            .clone()
             .join(format!("ED-{expedition_day:02}"))
-            .join(metadata.name.to_string());
+            .join(&metadata.name);
 
-        self.missions.insert(metadata.name.clone(), Mission {
-            path: mission_path.clone(),
-            metadata: metadata.clone(), 
-            committed_files: vec![],
-            staged_files: vec![],
-            manifest: Manifest::new(mission_path.clone().join("manifest.json"), Some(mission_path))
-        });
+        self.missions.insert(
+            metadata.name.clone(),
+            Mission {
+                path: mission_path.clone(),
+                metadata: metadata.clone(),
+                committed_files: vec![],
+                staged_files: vec![],
+                manifest: Manifest::new(
+                    mission_path.clone().join("manifest.json"),
+                    Some(mission_path),
+                ),
+            },
+        );
 
         self.countries.insert(metadata.country.clone());
         self.last_country = Some(metadata.country);
@@ -72,7 +80,7 @@ pub fn build_dataset(name: String, root: std::path::PathBuf, day_0: DateTime<Utc
         committed_files: vec![],
         staged_files: vec![],
         pushed: false,
-        version: "".to_string()
+        version: "".to_string(),
     }
 }
 
@@ -98,24 +106,33 @@ pub struct Metadata {
 }
 
 pub fn build_metadata(
-    timestamp: DateTime<Utc>, 
-    device: String, 
-    country: String, 
+    timestamp: DateTime<Utc>,
+    device: String,
+    country: String,
     region: String,
     site: String,
     name: String,
-    notes: String) -> Metadata {
-        Metadata { timestamp, device, country, region, site, name, notes }
+    notes: String,
+) -> Metadata {
+    Metadata {
+        timestamp,
+        device,
+        country,
+        region,
+        site,
+        name,
+        notes,
     }
+}
 
 pub fn build_mission_metadata(args: &InitMissionArgs) -> Metadata {
     build_metadata(
-        args.timestamp.into(), 
-        args.device.clone(), 
-        args.country.clone(), 
-        args.region.clone(), 
-        args.site.clone(), 
+        args.timestamp.into(),
+        args.device.clone(),
+        args.country.clone(),
+        args.region.clone(),
+        args.site.clone(),
         args.name.clone(),
-        args.message.clone().unwrap_or(String::new())
+        args.message.clone().unwrap_or_default(),
     )
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -15,15 +15,14 @@ struct ManifestData {
 }
 
 impl Manifest {
+    #[allow(dead_code)]
+    // TODO: implement validate and remove this
     fn validate(&self) -> bool {
         true
     }
 
     pub fn new(path: std::path::PathBuf, root: Option<std::path::PathBuf>) -> Manifest {
-        Manifest {
-            path, 
-            root
-        }
+        Manifest { path, root }
     }
 
     // fn get_dict(&self) -> Result<Box<HashMap<std::path::PathBuf, ManifestData>>, Box<dyn Error>> {


### PR DESCRIPTION
This PR runs a `cargo clippy` and corrects or silences any warnings, followed by a `cargo fmt` to correct code formatting. 