### PR TITLE
Feature/default trait

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,9 @@ impl E4EDMConfig {
             Ok(config)
         } else {
             // Return a default config if the file does not exist
-            Ok(E4EDMConfig::default())
+            let mut config = E4EDMConfig::default();
+            config.config_path = config_path;
+            Ok(config);
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,19 @@ pub struct E4EDMConfig {
     dataset_dir: Option<std::path::PathBuf>,
 }
 
+impl Default for E4EDMConfig {
+    fn default() -> Self {
+        E4EDMConfig {
+            config_path: std::path::PathBuf::new().join("."),
+            active_dataset: None,
+            active_mission: None,
+            datasets: HashMap::new(),
+            version: VERSION.to_string(),
+            dataset_dir: None,
+        }
+    }
+}
+
 impl E4EDMConfig {
     pub fn save(&self) -> Result<()> {
         let config_str = toml::to_string(&self)?;
@@ -26,13 +39,6 @@ impl E4EDMConfig {
     }
 
     pub fn build() -> Result<E4EDMConfig> {
-        Ok(E4EDMConfig {
-            config_path: std::path::PathBuf::new().join("."),
-            active_dataset: None,
-            active_mission: None,
-            datasets: HashMap::new(),
-            version: VERSION.to_string(),
-            dataset_dir: None,
-        })
+        Ok(E4EDMConfig::default())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,7 +57,7 @@ impl E4EDMConfig {
             // Return a default config if the file does not exist
             let mut config = E4EDMConfig::default();
             config.config_path = config_path;
-            Ok(config);
+            Ok(config)
         }
     }
 }


### PR DESCRIPTION
Used the default trait to be compatible with the current E4EDMConfig code in main. Need to ensure that config_path is initialized properly when config_file_path does not exist (when default trait called).