### PR TITLE
feat: add macos-14 runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Now generates binary that works on Macs with M1 processors and later.